### PR TITLE
keep URL hash when redirecting

### DIFF
--- a/background.js
+++ b/background.js
@@ -3,7 +3,7 @@ function remove_searchparams(requestDetails) {
     const host = url.host;
     if (!host.includes("www.wikipedia.org") && host.includes("wikipedia.org") && !host.endsWith("m.wikipedia.org")) {
         const new_host = host.replace("wikipedia.org", "m.wikipedia.org");
-        const mobile_url = url.protocol + "//" + new_host + url.pathname + url.search;
+        const mobile_url = url.protocol + "//" + new_host + url.pathname + url.search + url.hash;
         return {
             redirectUrl: mobile_url
         };


### PR DESCRIPTION
this is needed so links like https://en.wikipedia.org/wiki/Laki#Consequences_in_Europe work as expected